### PR TITLE
Fix bug in ArrayTypeKeyInfo::KeyTy constructor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,8 @@ Improvements:
 Bug fixes:
 
 * Support pointer to arrays as function arguments
+* Fix in DFFICtx for arrays: arrays of the same type with a different number of
+  elements could be considered equal!
 
 0.2.2
 -----

--- a/lib/dffictx.h
+++ b/lib/dffictx.h
@@ -129,7 +129,7 @@ struct ArrayTypeKeyInfo
 
     KeyTy(QualType EltTy, uint64_t NumElts):
       EltTy_(EltTy),
-      NumElts_(NumElts_)
+      NumElts_(NumElts)
     { }
 
     KeyTy(ArrayType const* AT):
@@ -137,7 +137,7 @@ struct ArrayTypeKeyInfo
     { }
 
     bool operator==(KeyTy const& O) const {
-      return EltTy_ == O.EltTy_ && NumElts_ == O.NumElts_;
+      return (EltTy_ == O.EltTy_) && (NumElts_ == O.NumElts_);
     }
 
     bool operator!=(KeyTy const& O) const {


### PR DESCRIPTION
The number of elements wasn't correctly set by one constructor, leading
to invalid lookups in the context!