### PR TITLE
Inline anonymous members within composite types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ message(STATUS "LLVM prefix: ${LLVM_PREFIX}")
 
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" "${LLVM_CMAKE}")
 set(Clang_DIR "${LLVM_PREFIX}/lib/cmake/clang")
@@ -148,6 +151,7 @@ set(DFFI_SRC
   lib/dffi_impl_clang_res.cpp
   lib/dffi_types.cpp
   lib/dffictx.cpp
+  lib/anon_member_inliner.cpp
 )
 
 get_source_file_property(_obj_depends lib/dffi_impl_clang_res.cpp OBJECT_DEPENDS)

--- a/bindings/python/cobj.cpp
+++ b/bindings/python/cobj.cpp
@@ -446,7 +446,7 @@ std::string getFormatDescriptorImpl(Type const* Ty, BTyFunc BTyFormat, PtrTyFunc
       std::string Ret;
       auto* STy = cast<StructType>(Ty);
       size_t CurIdx = 0;
-      for (auto const& F: STy->getFields()) {
+      for (auto const& F: STy->getOrgFields()) {
         const size_t Off = F.getOffset();
         const auto* FTy = F.getType();
         if (CurIdx < Off) {

--- a/bindings/python/tests/anon_struct.py
+++ b/bindings/python/tests/anon_struct.py
@@ -34,5 +34,4 @@ A = CU.types.A()
 Obj = A.s
 Ty = pydffi.typeof(Obj)
 fields = [f.name for f in iter(Ty)]
-assert(fields[0] == "a")
-assert(fields[1] == "b")
+assert(set(fields) == set(("a","b")))

--- a/include/dffi/iterator.h
+++ b/include/dffi/iterator.h
@@ -1,0 +1,370 @@
+// From LLVM's iterator.h.
+//
+//===- iterator.h - Utilities for using and defining iterators --*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DFFI_ADT_ITERATOR_H
+#define DFFI_ADT_ITERATOR_H
+
+#include <dffi/iterator_range.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace dffi {
+
+/// CRTP base class which implements the entire standard iterator facade
+/// in terms of a minimal subset of the interface.
+///
+/// Use this when it is reasonable to implement most of the iterator
+/// functionality in terms of a core subset. If you need special behavior or
+/// there are performance implications for this, you may want to override the
+/// relevant members instead.
+///
+/// Note, one abstraction that this does *not* provide is implementing
+/// subtraction in terms of addition by negating the difference. Negation isn't
+/// always information preserving, and I can see very reasonable iterator
+/// designs where this doesn't work well. It doesn't really force much added
+/// boilerplate anyways.
+///
+/// Another abstraction that this doesn't provide is implementing increment in
+/// terms of addition of one. These aren't equivalent for all iterator
+/// categories, and respecting that adds a lot of complexity for little gain.
+///
+/// Classes wishing to use `iterator_facade_base` should implement the following
+/// methods:
+///
+/// Forward Iterators:
+///   (All of the following methods)
+///   - DerivedT &operator=(const DerivedT &R);
+///   - bool operator==(const DerivedT &R) const;
+///   - const T &operator*() const;
+///   - T &operator*();
+///   - DerivedT &operator++();
+///
+/// Bidirectional Iterators:
+///   (All methods of forward iterators, plus the following)
+///   - DerivedT &operator--();
+///
+/// Random-access Iterators:
+///   (All methods of bidirectional iterators excluding the following)
+///   - DerivedT &operator++();
+///   - DerivedT &operator--();
+///   (and plus the following)
+///   - bool operator<(const DerivedT &RHS) const;
+///   - DifferenceTypeT operator-(const DerivedT &R) const;
+///   - DerivedT &operator+=(DifferenceTypeT N);
+///   - DerivedT &operator-=(DifferenceTypeT N);
+///
+template <typename DerivedT, typename IteratorCategoryT, typename T,
+          typename DifferenceTypeT = std::ptrdiff_t, typename PointerT = T *,
+          typename ReferenceT = T &>
+class iterator_facade_base
+    : public std::iterator<IteratorCategoryT, T, DifferenceTypeT, PointerT,
+                           ReferenceT> {
+protected:
+  enum {
+    IsRandomAccess = std::is_base_of<std::random_access_iterator_tag,
+                                     IteratorCategoryT>::value,
+    IsBidirectional = std::is_base_of<std::bidirectional_iterator_tag,
+                                      IteratorCategoryT>::value,
+  };
+
+  /// A proxy object for computing a reference via indirecting a copy of an
+  /// iterator. This is used in APIs which need to produce a reference via
+  /// indirection but for which the iterator object might be a temporary. The
+  /// proxy preserves the iterator internally and exposes the indirected
+  /// reference via a conversion operator.
+  class ReferenceProxy {
+    friend iterator_facade_base;
+
+    DerivedT I;
+
+    ReferenceProxy(DerivedT I) : I(std::move(I)) {}
+
+  public:
+    operator ReferenceT() const { return *I; }
+  };
+
+public:
+  DerivedT operator+(DifferenceTypeT n) const {
+    static_assert(std::is_base_of<iterator_facade_base, DerivedT>::value,
+                  "Must pass the derived type to this template!");
+    static_assert(
+        IsRandomAccess,
+        "The '+' operator is only defined for random access iterators.");
+    DerivedT tmp = *static_cast<const DerivedT *>(this);
+    tmp += n;
+    return tmp;
+  }
+  friend DerivedT operator+(DifferenceTypeT n, const DerivedT &i) {
+    static_assert(
+        IsRandomAccess,
+        "The '+' operator is only defined for random access iterators.");
+    return i + n;
+  }
+  DerivedT operator-(DifferenceTypeT n) const {
+    static_assert(
+        IsRandomAccess,
+        "The '-' operator is only defined for random access iterators.");
+    DerivedT tmp = *static_cast<const DerivedT *>(this);
+    tmp -= n;
+    return tmp;
+  }
+
+  DerivedT &operator++() {
+    static_assert(std::is_base_of<iterator_facade_base, DerivedT>::value,
+                  "Must pass the derived type to this template!");
+    return static_cast<DerivedT *>(this)->operator+=(1);
+  }
+  DerivedT operator++(int) {
+    DerivedT tmp = *static_cast<DerivedT *>(this);
+    ++*static_cast<DerivedT *>(this);
+    return tmp;
+  }
+  DerivedT &operator--() {
+    static_assert(
+        IsBidirectional,
+        "The decrement operator is only defined for bidirectional iterators.");
+    return static_cast<DerivedT *>(this)->operator-=(1);
+  }
+  DerivedT operator--(int) {
+    static_assert(
+        IsBidirectional,
+        "The decrement operator is only defined for bidirectional iterators.");
+    DerivedT tmp = *static_cast<DerivedT *>(this);
+    --*static_cast<DerivedT *>(this);
+    return tmp;
+  }
+
+  bool operator!=(const DerivedT &RHS) const {
+    return !static_cast<const DerivedT *>(this)->operator==(RHS);
+  }
+
+  bool operator>(const DerivedT &RHS) const {
+    static_assert(
+        IsRandomAccess,
+        "Relational operators are only defined for random access iterators.");
+    return !static_cast<const DerivedT *>(this)->operator<(RHS) &&
+           !static_cast<const DerivedT *>(this)->operator==(RHS);
+  }
+  bool operator<=(const DerivedT &RHS) const {
+    static_assert(
+        IsRandomAccess,
+        "Relational operators are only defined for random access iterators.");
+    return !static_cast<const DerivedT *>(this)->operator>(RHS);
+  }
+  bool operator>=(const DerivedT &RHS) const {
+    static_assert(
+        IsRandomAccess,
+        "Relational operators are only defined for random access iterators.");
+    return !static_cast<const DerivedT *>(this)->operator<(RHS);
+  }
+
+  PointerT operator->() { return &static_cast<DerivedT *>(this)->operator*(); }
+  PointerT operator->() const {
+    return &static_cast<const DerivedT *>(this)->operator*();
+  }
+  ReferenceProxy operator[](DifferenceTypeT n) {
+    static_assert(IsRandomAccess,
+                  "Subscripting is only defined for random access iterators.");
+    return ReferenceProxy(static_cast<DerivedT *>(this)->operator+(n));
+  }
+  ReferenceProxy operator[](DifferenceTypeT n) const {
+    static_assert(IsRandomAccess,
+                  "Subscripting is only defined for random access iterators.");
+    return ReferenceProxy(static_cast<const DerivedT *>(this)->operator+(n));
+  }
+};
+
+/// CRTP base class for adapting an iterator to a different type.
+///
+/// This class can be used through CRTP to adapt one iterator into another.
+/// Typically this is done through providing in the derived class a custom \c
+/// operator* implementation. Other methods can be overridden as well.
+template <
+    typename DerivedT, typename WrappedIteratorT,
+    typename IteratorCategoryT =
+        typename std::iterator_traits<WrappedIteratorT>::iterator_category,
+    typename T = typename std::iterator_traits<WrappedIteratorT>::value_type,
+    typename DifferenceTypeT =
+        typename std::iterator_traits<WrappedIteratorT>::difference_type,
+    typename PointerT = typename std::conditional<
+        std::is_same<T, typename std::iterator_traits<
+                            WrappedIteratorT>::value_type>::value,
+        typename std::iterator_traits<WrappedIteratorT>::pointer, T *>::type,
+    typename ReferenceT = typename std::conditional<
+        std::is_same<T, typename std::iterator_traits<
+                            WrappedIteratorT>::value_type>::value,
+        typename std::iterator_traits<WrappedIteratorT>::reference, T &>::type>
+class iterator_adaptor_base
+    : public iterator_facade_base<DerivedT, IteratorCategoryT, T,
+                                  DifferenceTypeT, PointerT, ReferenceT> {
+  using BaseT = typename iterator_adaptor_base::iterator_facade_base;
+
+protected:
+  WrappedIteratorT I;
+
+  iterator_adaptor_base() = default;
+
+  explicit iterator_adaptor_base(WrappedIteratorT u) : I(std::move(u)) {
+    static_assert(std::is_base_of<iterator_adaptor_base, DerivedT>::value,
+                  "Must pass the derived type to this template!");
+  }
+
+  const WrappedIteratorT &wrapped() const { return I; }
+
+public:
+  using difference_type = DifferenceTypeT;
+
+  DerivedT &operator+=(difference_type n) {
+    static_assert(
+        BaseT::IsRandomAccess,
+        "The '+=' operator is only defined for random access iterators.");
+    I += n;
+    return *static_cast<DerivedT *>(this);
+  }
+  DerivedT &operator-=(difference_type n) {
+    static_assert(
+        BaseT::IsRandomAccess,
+        "The '-=' operator is only defined for random access iterators.");
+    I -= n;
+    return *static_cast<DerivedT *>(this);
+  }
+  using BaseT::operator-;
+  difference_type operator-(const DerivedT &RHS) const {
+    static_assert(
+        BaseT::IsRandomAccess,
+        "The '-' operator is only defined for random access iterators.");
+    return I - RHS.I;
+  }
+
+  // We have to explicitly provide ++ and -- rather than letting the facade
+  // forward to += because WrappedIteratorT might not support +=.
+  using BaseT::operator++;
+  DerivedT &operator++() {
+    ++I;
+    return *static_cast<DerivedT *>(this);
+  }
+  using BaseT::operator--;
+  DerivedT &operator--() {
+    static_assert(
+        BaseT::IsBidirectional,
+        "The decrement operator is only defined for bidirectional iterators.");
+    --I;
+    return *static_cast<DerivedT *>(this);
+  }
+
+  bool operator==(const DerivedT &RHS) const { return I == RHS.I; }
+  bool operator<(const DerivedT &RHS) const {
+    static_assert(
+        BaseT::IsRandomAccess,
+        "Relational operators are only defined for random access iterators.");
+    return I < RHS.I;
+  }
+
+  ReferenceT operator*() const { return *I; }
+};
+
+/// An iterator type that allows iterating over the pointees via some
+/// other iterator.
+///
+/// The typical usage of this is to expose a type that iterates over Ts, but
+/// which is implemented with some iterator over T*s:
+///
+/// \code
+///   using iterator = pointee_iterator<SmallVectorImpl<T *>::iterator>;
+/// \endcode
+template <typename WrappedIteratorT,
+          typename T = typename std::remove_reference<
+              decltype(**std::declval<WrappedIteratorT>())>::type>
+struct pointee_iterator
+    : iterator_adaptor_base<
+          pointee_iterator<WrappedIteratorT, T>, WrappedIteratorT,
+          typename std::iterator_traits<WrappedIteratorT>::iterator_category,
+          T> {
+  pointee_iterator() = default;
+  template <typename U>
+  pointee_iterator(U &&u)
+      : pointee_iterator::iterator_adaptor_base(std::forward<U &&>(u)) {}
+
+  T &operator*() const { return **this->I; }
+};
+
+template <typename RangeT, typename WrappedIteratorT =
+                               decltype(std::begin(std::declval<RangeT>()))>
+iterator_range<pointee_iterator<WrappedIteratorT>>
+make_pointee_range(RangeT &&Range) {
+  using PointeeIteratorT = pointee_iterator<WrappedIteratorT>;
+  return make_range(PointeeIteratorT(std::begin(std::forward<RangeT>(Range))),
+                    PointeeIteratorT(std::end(std::forward<RangeT>(Range))));
+}
+
+template <typename WrappedIteratorT,
+          typename T = decltype(&*std::declval<WrappedIteratorT>())>
+class pointer_iterator
+    : public iterator_adaptor_base<
+          pointer_iterator<WrappedIteratorT, T>, WrappedIteratorT,
+          typename std::iterator_traits<WrappedIteratorT>::iterator_category,
+          T> {
+  mutable T Ptr;
+
+public:
+  pointer_iterator() = default;
+
+  explicit pointer_iterator(WrappedIteratorT u)
+      : pointer_iterator::iterator_adaptor_base(std::move(u)) {}
+
+  T &operator*() { return Ptr = &*this->I; }
+  const T &operator*() const { return Ptr = &*this->I; }
+};
+
+template <typename RangeT, typename WrappedIteratorT =
+                               decltype(std::begin(std::declval<RangeT>()))>
+iterator_range<pointer_iterator<WrappedIteratorT>>
+make_pointer_range(RangeT &&Range) {
+  using PointerIteratorT = pointer_iterator<WrappedIteratorT>;
+  return make_range(PointerIteratorT(std::begin(std::forward<RangeT>(Range))),
+                    PointerIteratorT(std::end(std::forward<RangeT>(Range))));
+}
+
+// Wrapper iterator over iterator ItType, adding DataRef to the type of ItType,
+// to create NodeRef = std::pair<InnerTypeOfItType, DataRef>.
+template <typename ItType, typename NodeRef, typename DataRef>
+class WrappedPairNodeDataIterator
+    : public iterator_adaptor_base<
+          WrappedPairNodeDataIterator<ItType, NodeRef, DataRef>, ItType,
+          typename std::iterator_traits<ItType>::iterator_category, NodeRef,
+          std::ptrdiff_t, NodeRef *, NodeRef &> {
+  using BaseT = iterator_adaptor_base<
+      WrappedPairNodeDataIterator, ItType,
+      typename std::iterator_traits<ItType>::iterator_category, NodeRef,
+      std::ptrdiff_t, NodeRef *, NodeRef &>;
+
+  const DataRef DR;
+  mutable NodeRef NR;
+
+public:
+  WrappedPairNodeDataIterator(ItType Begin, const DataRef DR)
+      : BaseT(Begin), DR(DR) {
+    NR.first = DR;
+  }
+
+  NodeRef &operator*() const {
+    NR.second = *this->I;
+    return NR;
+  }
+};
+
+} // end namespace dffi
+
+#endif // DFFI_ADT_ITERATOR_H

--- a/include/dffi/iterator_extras.h
+++ b/include/dffi/iterator_extras.h
@@ -1,0 +1,42 @@
+#ifndef DFFI_ITERATORS_H
+#define DFFI_ITERATORS_H
+
+#include <dffi/iterator.h>
+
+namespace dffi {
+
+// Adapted from LLVM's STLExtras.h
+
+// mapped_iterator - This is a simple iterator adapter that causes a function to
+// be applied whenever operator* is invoked on the iterator.
+
+template <typename ItTy, typename FuncTy,
+          typename FuncReturnTy =
+            decltype(std::declval<FuncTy>()(*std::declval<ItTy>()))>
+class mapped_iterator
+    : public iterator_adaptor_base<
+             mapped_iterator<ItTy, FuncTy>, ItTy,
+             typename std::iterator_traits<ItTy>::iterator_category,
+             typename std::remove_reference<FuncReturnTy>::type> {
+public:
+  mapped_iterator(ItTy U, FuncTy F)
+    : mapped_iterator::iterator_adaptor_base(std::move(U)), F(std::move(F)) {}
+
+  ItTy getCurrent() { return this->I; }
+
+  FuncReturnTy operator*() { return F(*this->I); }
+
+private:
+  FuncTy F;
+};
+
+// map_iterator - Provide a convenient way to create mapped_iterators, just like
+// make_pair is useful for creating pairs...
+template <class ItTy, class FuncTy>
+inline mapped_iterator<ItTy, FuncTy> map_iterator(ItTy I, FuncTy F) { 
+  return mapped_iterator<ItTy, FuncTy>(std::move(I), std::move(F));
+}
+
+} // dffi
+
+#endif

--- a/include/dffi/iterator_range.h
+++ b/include/dffi/iterator_range.h
@@ -1,0 +1,71 @@
+// From LLVM's iterator_range.h
+//
+//===- iterator_range.h - A range adaptor for iterators ---------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This provides a very simple, boring adaptor for a begin and end iterator
+/// into a range type. This should be used to build range views that work well
+/// with range based for loops and range based constructors.
+///
+/// Note that code here follows more standards-based coding conventions as it
+/// is mirroring proposed interfaces for standardization.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DFFI_ADT_ITERATOR_RANGE_H
+#define DFFI_ADT_ITERATOR_RANGE_H
+
+#include <iterator>
+#include <utility>
+
+namespace dffi {
+
+/// A range adaptor for a pair of iterators.
+///
+/// This just wraps two iterators into a range-compatible interface. Nothing
+/// fancy at all.
+template <typename IteratorT>
+class iterator_range {
+  IteratorT begin_iterator, end_iterator;
+
+public:
+  //TODO: Add SFINAE to test that the Container's iterators match the range's
+  //      iterators.
+  template <typename Container>
+  iterator_range(Container &&c)
+  //TODO: Consider ADL/non-member begin/end calls.
+      : begin_iterator(c.begin()), end_iterator(c.end()) {}
+  iterator_range(IteratorT begin_iterator, IteratorT end_iterator)
+      : begin_iterator(std::move(begin_iterator)),
+        end_iterator(std::move(end_iterator)) {}
+
+  IteratorT begin() const { return begin_iterator; }
+  IteratorT end() const { return end_iterator; }
+};
+
+/// Convenience function for iterating over sub-ranges.
+///
+/// This provides a bit of syntactic sugar to make using sub-ranges
+/// in for loops a bit easier. Analogous to std::make_pair().
+template <class T> iterator_range<T> make_range(T x, T y) {
+  return iterator_range<T>(std::move(x), std::move(y));
+}
+
+template <typename T> iterator_range<T> make_range(std::pair<T, T> p) {
+  return iterator_range<T>(std::move(p.first), std::move(p.second));
+}
+
+template <typename T>
+iterator_range<decltype(adl_begin(std::declval<T>()))> drop_begin(T &&t,
+                                                                  int n) {
+  return make_range(std::next(adl_begin(t), n), adl_end(t));
+}
+}
+
+#endif

--- a/lib/anon_member_inliner.cpp
+++ b/lib/anon_member_inliner.cpp
@@ -1,0 +1,131 @@
+// Copyright 2019 Adrien Guinet <adrien@guinet.me>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <llvm/ADT/SmallSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/SetVector.h>
+#include <dffi/composite_type.h>
+#include <unordered_set>
+
+#include "dffi_impl.h"
+
+using namespace llvm;
+
+namespace dffi {
+
+void CompositeType::inlineAnonymousMembers()
+{
+  SmallVector<FieldsMapTy::iterator, 16> ToInline;
+  const auto ItEnd = FieldsMap_.end();
+  for (auto It = FieldsMap_.begin(); It != ItEnd; ++It) {
+    auto const& CF = *It->second;
+    if (CF.anonymous()) {
+      if (isa<CompositeType>(CF.getType())) {
+        ToInline.emplace_back(It);
+      }
+    }
+  }
+
+  InlinedFields_.reserve(ToInline.size());
+  for (auto const& It: ToInline) {
+    CompositeField const& CF = *It->second;
+    FieldsMap_.erase(It);
+    // We need to inline the type of this CF. We adjust the offset of the new
+    // fields thanks to the one of CF.
+    const unsigned CFOff = CF.getOffset();
+    for (auto const& ToInlineF: cast<CompositeType>(CF.getType())->getFields()) {
+      const char* Name = ToInlineF.getName();
+      InlinedFields_.emplace_back(CompositeField{Name, ToInlineF.getType(), CFOff+ToInlineF.getOffset()});
+    }
+  }
+
+  for (auto const& CF: InlinedFields_) {
+    FieldsMap_[CF.getName()] = &CF;
+  }
+}
+
+namespace details {
+
+void CUImpl::inlineCompositesAnonymousMembersImpl(std::unordered_set<CompositeType*>& Visited, CompositeType* CTy)
+{
+  if (!Visited.insert(CTy).second) {
+    return;
+  }
+
+  SmallVector<CompositeType*, 16> CTys;
+  for (auto& CF: CTy->getFields()) {
+    if (CF.anonymous()) {
+      // TODO: what to do when we have an enum?
+      if (auto* CFTy = dyn_cast<CompositeType>(CF.getType())) {
+        CTys.push_back(const_cast<CompositeType*>(CFTy));
+      }
+    }
+  }
+
+  for (auto* CFTy: CTys) {
+    inlineCompositesAnonymousMembersImpl(Visited, CFTy);
+  }
+
+  if (CTys.size() > 0) {
+    CTy->inlineAnonymousMembers();
+  }
+}
+
+void CUImpl::inlineCompositesAnonymousMembers()
+{
+  std::unordered_set<CompositeType*> Visited;
+  for (auto const& It: CompositeTys_) {
+    if (auto* CTy = dyn_cast<CompositeType>(It.getValue().get())) {
+      inlineCompositesAnonymousMembersImpl(Visited, CTy);
+    }
+  }
+#if 0
+  SetVector<CompositeType*> OrderedCTys;
+
+  {
+    SmallVector<CompositeType*, 8> WorkList;
+    for (auto const& It: CompositeTys_) {
+      WorkList.push_back(It->second.get());
+    }
+    std::unordered_set<CompositeType*> Visited;
+
+    while (!WorkList.empty()) {
+      CompositeType* Cur = WorkList.back();
+      WorkList.pop_back();
+      if (!Cur.insert(Visisted).second) {
+        continue;
+      }
+      bool Found = false;
+      for (auto& CF: Cur->getFields()) {
+        if (CF.getName().empty()) {
+          Found = true;
+          WorkList.push_back(CF.getType());
+        }
+      }
+      if (Found) {
+        OrderedCTys.insert(Cur);
+      }
+    }
+  }
+
+  // Let's walk through OrderedCTys backwards, and inline anonymous members
+  const auto ItEnd = OrderedCTys.end();
+  for (auto It = OrderedCTys.rbegin(); It != ItEnd; ++It) {
+    (*It)->inlineAnonymousMembers();
+  }
+#endif
+}
+
+} // details
+} // dffi

--- a/lib/dffi_impl.h
+++ b/lib/dffi_impl.h
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <sstream>
+#include <unordered_set>
 
 #include <llvm/ADT/IntrusiveRefCntPtr.h>
 #include <llvm/ADT/StringRef.h>
@@ -142,6 +143,7 @@ private:
 
 struct CUImpl
 {
+  
   CUImpl(DFFIImpl& DFFI);
 
   dffi::Type const* getType(llvm::StringRef Name) const;
@@ -179,6 +181,8 @@ struct CUImpl
   DFFICtx& getContext() { return DFFI_.getContext(); }
   DFFICtx const& getContext() const { return DFFI_.getContext(); }
 
+  void inlineCompositesAnonymousMembers();
+
   std::vector<std::string> getTypes() const;
   std::vector<std::string> getFunctions() const;
 
@@ -191,6 +195,9 @@ struct CUImpl
 
   // Temporary map used during debug metadata parsing
   AnonTysMap AnonTys_;
+
+private:
+  static void inlineCompositesAnonymousMembersImpl(std::unordered_set<CompositeType*>& Visited, CompositeType* CTy);
 };
 
 struct ASTGenWrappersAction: public clang::ASTFrontendAction

--- a/lib/dffi_types.cpp
+++ b/lib/dffi_types.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <llvm/ADT/StringRef.h>
 #include <dffi/config.h>
 #include <dffi/dffi.h>
 #include <dffi/composite_type.h>
@@ -236,6 +237,11 @@ CompositeField const* CompositeType::getField(const char* Name) const
     return nullptr;
   }
   return It->second;
+}
+
+bool CompositeField::anonymous() const {
+  // HACK
+  return llvm::StringRef{Name_}.startswith("__dffi_anon_");
 }
 
 void CompositeType::setBody(std::vector<CompositeField>&& Fields, uint64_t Size, unsigned Align) {

--- a/lib/types_printer.h
+++ b/lib/types_printer.h
@@ -258,7 +258,7 @@ private:
   {
     print_def(ss, Ty, None) << " {\n";
     size_t Idx = 0;
-    for (auto const& F: Ty->getFields()) {
+    for (auto const& F: Ty->getOrgFields()) {
       std::string Name = "__Field_" + std::to_string(Idx);
       ss << "  ";
       print_def(ss, F.getType(), Full, Name.c_str()) << ";\n";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_file("lit.site.cfg.in" "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg" ESCA
 
 if (BUILD_TESTS)
   set(TESTS
+    anon_members
     anon_struct
     anon_union
     array

--- a/tests/anon_members.cpp
+++ b/tests/anon_members.cpp
@@ -1,0 +1,84 @@
+// Copyright 2019 Adrien Guinet <adrien@guinet.me>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: "%build_dir/anon_members"
+
+#include <iostream>
+#include <dffi/dffi.h>
+
+using namespace dffi;
+
+typedef struct {
+  char buf[7];
+  struct {
+    int a;
+    int b;
+    struct {
+      union {
+        int c;
+        float d;
+      };
+      int e;
+    };
+  };
+  int f;
+} A;
+
+int main()
+{
+  DFFI::initialize();
+
+  CCOpts Opts;
+  Opts.OptLevel = 2;
+
+  DFFI Jit(Opts);
+
+  std::string Err;
+  auto CU = Jit.compile(R"(
+typedef struct {
+  char buf[7];
+  struct {
+    int a;
+    int b;
+    struct {
+      union {
+        int c;
+        float d;
+      };
+      int e;
+    };
+  };
+  int f;
+} A;
+
+A foo() {
+  A ret;
+  ret.a = 1;
+  ret.b = 2;
+  ret.c = 4;
+  ret.e = 5;
+  ret.f = 6;
+  return ret;
+}
+)", Err);
+  if (!CU) {
+    std::cerr << Err << std::endl;
+    return 1;
+  }
+
+  A a;
+  CU.getFunction("foo").call(&a, NULL);
+  const bool Valid = (a.a == 1 && a.b == 2 && a.c == 4 && a.e == 5 && a.f == 6);
+  return Valid?0:1;
+}

--- a/tests/typedef.cpp
+++ b/tests/typedef.cpp
@@ -76,7 +76,7 @@ void dump(SA a)
   // CHECK: b
   // CHECK: c
   // CHECK: d
-  for (auto const& F: static_cast<StructType const*>(STy)->getFields()) {
+  for (auto const& F: static_cast<StructType const*>(STy)->getOrgFields()) {
     std::cout << F.getName() << std::endl;
   }
 

--- a/tests/union.cpp
+++ b/tests/union.cpp
@@ -80,7 +80,7 @@ void set(union A* a) {
   }
 
   auto* UTy = CU.getUnionType("A");
-  auto const& Fields = UTy->getFields();
+  auto const& Fields = UTy->getOrgFields();
   // CHECK: a
   // CHECK: b
   // CHECK: c


### PR DESCRIPTION
We use the string => field map in CompositeType as a "view" of what can
be accessed, and add a new pass that inlines anonymous members. This
doesn't support anonynmous enums within composite types for now.