### PR TITLE
Add support to create a pointer with an arbitrary value

### DIFF
--- a/bindings/python/pydffi.cpp
+++ b/bindings/python/pydffi.cpp
@@ -348,10 +348,16 @@ std::unique_ptr<CUnionObj> uniontype_new(UnionType const& UTy, const char* Field
   return Ret;
 } 
 
+std::unique_ptr<CPointerObj> cpointerobj_new_val(PointerType const& PTy, uintptr_t PtrVal)
+{
+  return std::unique_ptr<CPointerObj>{new CPointerObj{PTy, Data<void*>::emplace_owned((void*)PtrVal)}};
+}
+
 std::unique_ptr<CPointerObj> cpointerobj_new(PointerType const& PTy)
 {
-  return std::unique_ptr<CPointerObj>{new CPointerObj{PTy, Data<void*>::emplace_owned(nullptr)}};
+  return cpointerobj_new_val(PTy, 0);
 }
+
 
 std::unique_ptr<CArrayObj> carraytype_new(ArrayType const& ATy)
 {
@@ -484,6 +490,7 @@ PYBIND11_MODULE(PYDFFI_EXT_NAME, m)
   py::class_<PointerType>(m, "PointerType", type)
     .def("pointee", &PointerType::getPointee, py::return_value_policy::reference_internal)
     .def("__call__", cpointerobj_new, py::keep_alive<0,1>())
+    .def("__call__", cpointerobj_new_val, py::keep_alive<0,1>())
     ;
 
   py::class_<ArrayType>(m, "ArrayType", type)

--- a/bindings/python/tests/test_ptrs.py
+++ b/bindings/python/tests/test_ptrs.py
@@ -1,0 +1,32 @@
+# Copyright 2018 Adrien Guinet <adrien@guinet.me>
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pydffi
+import sys
+import struct
+
+from common import DFFITest
+
+class PtrsTest(DFFITest):
+    def test_ptrs(self):
+        F = self.FFI
+        O = F.UInt32Ty(4)
+        P = pydffi.ptr(O)
+
+        NewP = F.UInt32PtrTy(int(P.value))
+        self.assertEqual(NewP.obj, O)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I wanted to avoid this to force people using pointers they got from C
(to avoid use-after-free for instance), but it looks like it could be
useful to some people after all.