### PR TITLE
Lazily compile FFI wrappers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 -----
 
 * C++ compilation mode where extern "C" functions can be called
+* FFI wrappers are now only compiled when needed, dividing cdef loading time by ~2
 
 0.8.0
 -----

--- a/include/dffi/dffi.h
+++ b/include/dffi/dffi.h
@@ -60,6 +60,8 @@ struct CCOpts
   CXXMode CXX = CXXMode::NoCXX;
   bool GNUExtensions = true;
 
+  bool LazyJITWrappers = true;
+
   bool hasCXX() const { return CXX != CXXMode::NoCXX; }
 
   std::string getSysroot() const;

--- a/lib/dffi_impl.cpp
+++ b/lib/dffi_impl.cpp
@@ -548,10 +548,12 @@ CUImpl* DFFIImpl::compile(StringRef const Code, StringRef CUName, bool IncludeDe
       CU->parseFunctionAlias(F);
     }
     CU->FuncTys_[FName] = DFTy;
-    auto Id = getFuncTypeWrapperId(DFTy);
-    if (!Id.second) {
-      // TODO: if varag, do we always generate the wrapper for the version w/o varargs?
-      genFuncTypeWrapper(Printer, Id.first, Wrappers, DFTy, {});
+    if (!Opts_.LazyJITWrappers) {
+      auto Id = getFuncTypeWrapperId(DFTy);
+      if (!Id.second) {
+        // TODO: if varag, do we always generate the wrapper for the version w/o varargs?
+        genFuncTypeWrapper(Printer, Id.first, Wrappers, DFTy, {});
+      }
     }
   }
 

--- a/tests/anon_struct.cpp
+++ b/tests/anon_struct.cpp
@@ -33,6 +33,7 @@ int main()
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/asm_redirect.cpp
+++ b/tests/asm_redirect.cpp
@@ -25,6 +25,7 @@ int main(int argc, char** argv)
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/attrs.cpp
+++ b/tests/attrs.cpp
@@ -25,6 +25,7 @@ int main(int argc, char** argv)
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/decl.cpp
+++ b/tests/decl.cpp
@@ -25,6 +25,7 @@ int main(int argc, char** argv)
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/decl_cxx.cpp
+++ b/tests/decl_cxx.cpp
@@ -28,6 +28,7 @@ int main(int argc, char** argv)
   CCOpts Opts;
   Opts.OptLevel = 2;
   Opts.CXX = CXXMode::Std11;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/inline.cpp
+++ b/tests/inline.cpp
@@ -25,6 +25,7 @@ int main()
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/multiple_defs.cpp
+++ b/tests/multiple_defs.cpp
@@ -25,6 +25,7 @@ int main()
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/system_headers.cpp
+++ b/tests/system_headers.cpp
@@ -25,6 +25,7 @@ int main(int argc, char** argv)
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 

--- a/tests/varargs.cpp
+++ b/tests/varargs.cpp
@@ -33,6 +33,7 @@ int main()
 
   CCOpts Opts;
   Opts.OptLevel = 2;
+  Opts.LazyJITWrappers = false;
 
   DFFI Jit(Opts);
 


### PR DESCRIPTION
This reduces cdef loading time by ~2